### PR TITLE
Add enum subjects

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -50,10 +50,10 @@ TutorsPet is a **desktop app designed for private tutors to manage students’ i
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
 * Items in square brackets are optional.<br>
-  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/sec3` or as `n/John Doe`.
+  e.g `n/NAME [t/SUBJECT]` can be used as `n/John Doe t/sec3` or as `n/John Doe`.
 
 * Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/sec1`, `t/physics t/maths` etc.
+  e.g. `[t/SUBJECT]…​` can be used as ` ` (i.e. 0 times), `t/sec1`, `t/physics t/maths` etc.
 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
@@ -86,13 +86,13 @@ Format: `schedule`
 
 Adds a student’s contact to TutorsPet.
 
-Format: `add n/NAME p/PHONE [s/SCHOOL] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/TAG]…​ [l/LESSON]…​`
+Format: `add n/NAME p/PHONE [s/SCHOOL] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT]…​ [l/LESSON]…​`
 
 <div markdown="span" class="alert alert-primary">
 
 :bulb:**Tip:**<br>
 
-* `n/NAME p/PHONE` are compulsory fields that must be provided, while `s/SCHOOL e/EMAIL a/ADDRESS gn/GUARDIAN_NAME gp/GUARDIAN_PHONE [t/TAG]…​ [l/LESSON]…​` are optional.
+* `n/NAME p/PHONE` are compulsory fields that must be provided, while `s/SCHOOL e/EMAIL a/ADDRESS gn/GUARDIAN_NAME gp/GUARDIAN_PHONE [t/SUBJECT]…​ [l/LESSON]…​` are optional.
   
 * A student’s contact can have any number of subjects (including 0)
   
@@ -115,7 +115,7 @@ Format: `list`
 
 Edits an existing student in TutorsPet.
 
-Format: `edit INDEX [n/NAME] [s/SCHOOL] [p/PHONE] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/TAG] [l/LESSON]…​`
+Format: `edit INDEX [n/NAME] [s/SCHOOL] [p/PHONE] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT] [l/LESSON]…​`
 
 * Edits the student at the specified `INDEX`.
 * The index refers to the index number shown in the displayed student list.
@@ -147,7 +147,7 @@ Format: `search [n/KEYWORDS] [s/KEYWORDS] [t/KEYWORDS] [MORE_KEYWORDS]`
   E.g. `Alice Tan` will return `Alice Ng` and `Bob Tan`.
 
 Examples:
-* `search n/eliza s/woodlands t/math` returns student whose name is `Eliza`, students who are studying in `woodlands primary school`, and students with the `math` tag
+* `search n/eliza s/woodlands t/math` returns student whose name is `Eliza`, students who are studying in `woodlands primary school`, and students with the `math` subject
 * `search n/Patrick Lim` returns `patrick lim` and `Lim Zi Ying`
 * `search s/woodlands` returns students studying in `woodlands primary school` and `woodlands secondary school`
 * `search s/raffles hwa` returns students studying in `Raffles Institution` and `Hwa chong institution`
@@ -190,21 +190,21 @@ Examples:
 * `search s/woodlands` returns students studying in `woodlands primary school` and `woodlands secondary school`
 * `search s/raffles hwa` returns students studying in `Raffles Institution` and `Hwa chong institution`
 
-### Searching for a contact by tag: `search t/...`
-Searches for a student's contact with a specific tag using keywords
+### Searching for a contact by subject: `search t/...`
+Searches for a student's contact with a specific subject using keywords
 
 Format: `search t/KEYWORD [MORE_KEYWORDS]`
 
 * The search is case-insensitive. <br/>
-  e.g `MATH` will match students with tag `math`
+  e.g `MATH` will match students with subject `math`
 * Only the stated keyword is searched.
 * Only full words will be matched e.g. `Math` will not match `Maths`
 
 Examples:
-* `search t/science` returns students with the tag `SCIENCE` and `science`
+* `search t/chemistry`, `search t/chemistry`, and `search t/chemistry` can all return students with the subject `chemistry`
 
 ### Sorting contacts: `sort`
-Sorting for student’s contacts by name, school, tags or lessons.
+Sorting for student’s contacts by name, school, subjects or lessons.
 
 Format: `search n/`, `search s/`, `search t/` or `search l/`
 
@@ -295,7 +295,7 @@ If your changes to the data file makes its format invalid, TutorsPet will discar
 
 ##Coming soon
 
-### Add a subject to teach`[coming in v1.4]`
+### Add a subject to teach`[coming in v2.0]`
 
 _Format: `add-subject SUBJECT_NAME` <br> In v1.3, there is a fixed list of subjects that is available to teach and can be tagged in TutorsPet, 
 while in v1.4, more personalised subjects can be added in._
@@ -321,10 +321,10 @@ _Details coming soon ..._
 
 Action | Format, Examples
 --------|------------------
-**Add** | `add n/NAME p/PHONE [s/SCHOOL] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/TAG]…​ [l/LESSON]…​` <br> e.g., `add n/Bob Lee p/87654321 s/Def Secondary School a/Bob street, block 321, #01-02 gn/John Lee gp/12345678 t/sec3`
+**Add** | `add n/NAME p/PHONE [s/SCHOOL] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT]…​ [l/LESSON]…​` <br> e.g., `add n/Bob Lee p/87654321 s/Def Secondary School a/Bob street, block 321, #01-02 gn/John Lee gp/12345678 t/sec3`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit** | `edit INDEX [n/NAME] [s/SCHOOL] [p/PHONE] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/TAG]…​ [l/LESSON]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit** | `edit INDEX [n/NAME] [s/SCHOOL] [p/PHONE] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT]…​ [l/LESSON]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
 **Search** | `search [n/KEYWORDS] [s/KEYWORDS] [t/KEYWORDS] [MORE_KEYWORDS]`<br> e.g., `search n/James Jake s/woodlands t/science`
 **Schedule** | `schedule`
 **Detail** | `detail INDEX` <br> e.g., `detail 1`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -300,8 +300,8 @@ If your changes to the data file makes its format invalid, TutorsPet will discar
 
 ### Add a subject to teach`[coming in v2.0]`
 
-_Format: `add-subject SUBJECT_NAME` <br> In v1.3, there is a fixed list of subjects that is available to teach and can be tagged in TutorsPet, 
-while in v1.4, more personalised subjects can be added in._
+_Format: `add-subject SUBJECT_NAME` <br> Currently, there is a fixed list of subjects that is available to teach and can be tagged in TutorsPet, 
+while in v2.0, more personalised subjects can be added in._
 
 ### Undo/Redo `[coming in v2.0]`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -324,11 +324,11 @@ _Details coming soon ..._
 
 Action | Format, Examples
 --------|------------------
-**Add** | `add n/NAME p/PHONE [s/SCHOOL] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT]…​ [l/LESSON]…​` <br> e.g., `add n/Bob Lee p/87654321 s/Def Secondary School a/Bob street, block 321, #01-02 gn/John Lee gp/12345678 t/sec3`
+**Add** | `add n/NAME p/PHONE [s/SCHOOL] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT]…​ [l/LESSON]…​` <br> e.g., `add n/Bob Lee p/87654321 s/Def Secondary School a/Bob street, block 321, #01-02 gn/John Lee gp/12345678 t/geo`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit** | `edit INDEX [n/NAME] [s/SCHOOL] [p/PHONE] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT]…​ [l/LESSON]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
-**Search** | `search [n/KEYWORDS] [s/KEYWORDS] [t/KEYWORDS] [MORE_KEYWORDS]`<br> e.g., `search n/James Jake s/woodlands t/science`
+**Search** | `search [n/KEYWORDS] [s/KEYWORDS] [t/KEYWORDS] [MORE_KEYWORDS]`<br> e.g., `search n/James Jake s/woodlands t/eng`
 **Schedule** | `schedule`
 **Detail** | `detail INDEX` <br> e.g., `detail 1`
 **List** | `list`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -50,11 +50,14 @@ TutorsPet is a **desktop app designed for private tutors to manage students’ i
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
 * Items in square brackets are optional.<br>
-  e.g `n/NAME [t/SUBJECT]` can be used as `n/John Doe t/sec3` or as `n/John Doe`.
+  e.g `n/NAME [t/SUBJECT]` can be used as `n/John Doe t/econ` or as `n/John Doe`.
 
 * Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/SUBJECT]…​` can be used as ` ` (i.e. 0 times), `t/sec1`, `t/physics t/maths` etc.
-
+  e.g. `[t/SUBJECT]…​` can be used as ` ` (i.e. 0 times), `t/chem`, `t/phys t/math` etc.
+  
+* Subjects are represented by abbreviated name. Available names are `bio`, `chem`, `cn`, `econ`, `eng`, `geo`, `hist`, `math`, `phys`.
+They represent subjects Biology, Chemistry, Chinese, Economics, English, Geography, History, Mathematics and Physics respectively.
+  
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
@@ -115,7 +118,7 @@ Format: `list`
 
 Edits an existing student in TutorsPet.
 
-Format: `edit INDEX [n/NAME] [s/SCHOOL] [p/PHONE] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT] [l/LESSON]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [s/SCHOOL] [e/EMAIL] [a/ADDRESS] [gn/GUARDIAN_NAME] [gp/GUARDIAN_PHONE] [t/SUBJECT] [l/LESSON]…​`
 
 * Edits the student at the specified `INDEX`.
 * The index refers to the index number shown in the displayed student list.
@@ -123,8 +126,8 @@ Format: `edit INDEX [n/NAME] [s/SCHOOL] [p/PHONE] [e/EMAIL] [a/ADDRESS] [gn/GUAR
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * When editing subjects or lessons, the existing subjects or lessons of the student will be removed i.e adding of subjects or lessons are not cumulative.
-* You can remove all the student’s subjects by typing `t/` without
-    specifying any subjects after it.
+* You can remove all the student’s subjects by typing `t/` without specifying any subject names after it.
+* You can remove all the student’s lessons by typing `l/` without specifying any lesson details after it.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st student to be `91234567` and `johndoe@example.com` respectively.
@@ -147,7 +150,7 @@ Format: `search [n/KEYWORDS] [s/KEYWORDS] [t/KEYWORDS] [MORE_KEYWORDS]`
   E.g. `Alice Tan` will return `Alice Ng` and `Bob Tan`.
 
 Examples:
-* `search n/eliza s/woodlands t/math` returns student whose name is `Eliza`, students who are studying in `woodlands primary school`, and students with the `math` subject
+* `search n/eliza s/woodlands t/math` returns student whose name is `Eliza`, students who are studying in `woodlands primary school`, and students with `math` subject
 * `search n/Patrick Lim` returns `patrick lim` and `Lim Zi Ying`
 * `search s/woodlands` returns students studying in `woodlands primary school` and `woodlands secondary school`
 * `search s/raffles hwa` returns students studying in `Raffles Institution` and `Hwa chong institution`
@@ -201,7 +204,7 @@ Format: `search t/KEYWORD [MORE_KEYWORDS]`
 * Only full words will be matched e.g. `Math` will not match `Maths`
 
 Examples:
-* `search t/chemistry`, `search t/chemistry`, and `search t/chemistry` can all return students with the subject `chemistry`
+* `search t/CHEM`, `search t/chem`, and `search t/Chem` can all return students with the subject `chem`
 
 ### Sorting contacts: `sort`
 Sorting for student’s contacts by name, school, subjects or lessons.

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -83,18 +83,19 @@ public class EditCommandParser implements Parser<EditCommand> {
     }
 
     /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Tag>} containing zero tags.
+     * Parses {@code Collection<String> subjects} into a {@code Set<Tag>} if {@code subjects} is non-empty.
+     * If {@code subjects} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero subjects.
      */
-    private Optional<Set<Subject>> parseSubjectsForEdit(Collection<String> tags) throws ParseException {
-        assert tags != null;
+    private Optional<Set<Subject>> parseSubjectsForEdit(Collection<String> subjects) throws ParseException {
+        assert subjects != null;
 
-        if (tags.isEmpty()) {
+        if (subjects.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseSubjects(tagSet));
+        Collection<String> subjectSet = subjects.size() == 1 && subjects.contains("")
+                ? Collections.emptySet() : subjects;
+        return Optional.of(ParserUtil.parseSubjects(subjectSet));
     }
 
     private Optional<Set<Lesson>> parseLessonsForEdit(Collection<String> lessons) throws ParseException {

--- a/src/main/java/seedu/address/model/lesson/Lesson.java
+++ b/src/main/java/seedu/address/model/lesson/Lesson.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.person.Person;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
 
 public class Lesson implements Comparable<Lesson> {
 
@@ -80,8 +79,6 @@ public class Lesson implements Comparable<Lesson> {
     public void addPerson(Person person) {
         if (!containsPerson(person)) {
             persons.add(person);
-        } else {
-            throw new DuplicatePersonException();
         }
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -175,7 +175,7 @@ public class Person {
 
         Set<Subject> subjects = getSubjects();
         if (!subjects.isEmpty()) {
-            builder.append("; Tags: ");
+            builder.append("; Subjects: ");
             subjects.forEach(builder::append);
         }
 

--- a/src/main/java/seedu/address/model/subject/AvailableSubject.java
+++ b/src/main/java/seedu/address/model/subject/AvailableSubject.java
@@ -5,42 +5,24 @@ package seedu.address.model.subject;
  * Both abbreviated and full name are included for a subject.
  */
 public enum AvailableSubject {
-    bio("bio", "biology"),
-    biology("bio", "biology"),
+    bio("biology"),
+    chem("chemistry"),
+    cn("chinese"),
+    econ("economics"),
+    eng("english"),
+    geo("geography"),
+    hist("history"),
+    math("mathematics"),
+    phys("physics");
 
-    chem("chem", "chemistry"),
-    chemistry("chem", "chemistry"),
 
-    cn("cn", "chinese"),
-    chinese("cn", "chinese"),
-
-    econ("econ", "economics"),
-    economics("econ", "economics"),
-
-    eng("eng", "english"),
-    english("eng", "english"),
-
-    geo("geo", "geography"),
-    geography("geo", "geography"),
-
-    hist("hist", "history"),
-    history("hist","history"),
-
-    math("math","mathematics"),
-    mathematics("math","mathematics"),
-
-    phys("phys","physics"),
-    physics("phys", "physics");
-
-    private final String abbr;
     private final String full;
-    private AvailableSubject(String abbr, String full) {
-        this.abbr = abbr;
+    private AvailableSubject(String full) {
         this.full = full;
     }
     @Override
     public String toString() {
-        return abbr;
+        return full;
     }
 }
 

--- a/src/main/java/seedu/address/model/subject/AvailableSubject.java
+++ b/src/main/java/seedu/address/model/subject/AvailableSubject.java
@@ -1,0 +1,48 @@
+package seedu.address.model.subject;
+
+/**
+ * Represents a list of subjects available in TutorsPet.
+ * Both abbreviated and full name are included for a subject.
+ */
+public enum AvailableSubject {
+    bio("bio", "biology"),
+    biology("bio", "biology"),
+
+    chem("chem", "chemistry"),
+    chemistry("chem", "chemistry"),
+
+    cn("cn", "chinese"),
+    chinese("cn", "chinese"),
+
+    econ("econ", "economics"),
+    economics("econ", "economics"),
+
+    eng("eng", "english"),
+    english("eng", "english"),
+
+    geo("geo", "geography"),
+    geography("geo", "geography"),
+
+    hist("hist", "history"),
+    history("hist","history"),
+
+    math("math","mathematics"),
+    mathematics("math","mathematics"),
+
+    phys("phys","physics"),
+    physics("phys", "physics");
+
+    private final String abbr;
+    private final String full;
+    private AvailableSubject(String abbr, String full) {
+        this.abbr = abbr;
+        this.full = full;
+    }
+    @Override
+    public String toString() {
+        return abbr;
+    }
+}
+
+
+

--- a/src/main/java/seedu/address/model/subject/Subject.java
+++ b/src/main/java/seedu/address/model/subject/Subject.java
@@ -9,9 +9,10 @@ import java.util.Locale;
  * Guarantees: immutable; name is valid as declared in {@link #isValidSubjectName(String)}
  */
 public class Subject implements Comparable<Subject> {
-    public static final String MESSAGE_CONSTRAINTS = "Subjects should be from the list "
-            + "[biology, chemistry, chinese, economics, english, geography, history, mathematics, physics]"
-            + ", and their abbreviated names [bio, chem, cn, econ, eng, geo, hist, math, phys] are also acceptable";
+    public static final String MESSAGE_CONSTRAINTS = "Subject names should be an abbreviation from the list "
+            + "[bio, chem, cn, econ, eng, geo, hist, math, phys], which respectively means "
+            + "[biology, chemistry, chinese, economics, english, geography, history, mathematics, physics]";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String subjectName;
 
@@ -30,9 +31,11 @@ public class Subject implements Comparable<Subject> {
      * Returns true if a given string is a valid subject name.
      */
     public static boolean isValidSubjectName(String test) {
-        for (AvailableSubject subject : AvailableSubject.values()) {
-            if (subject.name().equals(test)) {
-                return true;
+        if(test.matches(VALIDATION_REGEX)){
+            for (AvailableSubject subject : AvailableSubject.values()) {
+                if (subject.name().equals(test)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/src/main/java/seedu/address/model/subject/Subject.java
+++ b/src/main/java/seedu/address/model/subject/Subject.java
@@ -5,13 +5,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.Locale;
 /**
- * Represents a Tag in TutorsPet.
+ * Represents a Subject in TutorsPet.
  * Guarantees: immutable; name is valid as declared in {@link #isValidSubjectName(String)}
  */
 public class Subject implements Comparable<Subject> {
-
-    public static final String MESSAGE_CONSTRAINTS = "Subject names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Subjects should be from the list "
+            + "[biology, chemistry, chinese, economics, english, geography, history, mathematics, physics]"
+            + ", and their abbreviated names [bio, chem, cn, econ, eng, geo, hist, math, phys] are also acceptable";
 
     public final String subjectName;
 
@@ -22,7 +22,7 @@ public class Subject implements Comparable<Subject> {
      */
     public Subject(String subjectName) {
         requireNonNull(subjectName);
-        checkArgument(isValidSubjectName(subjectName), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidSubjectName(subjectName.toLowerCase(Locale.ROOT)), MESSAGE_CONSTRAINTS);
         this.subjectName = subjectName;
     }
 
@@ -30,7 +30,12 @@ public class Subject implements Comparable<Subject> {
      * Returns true if a given string is a valid subject name.
      */
     public static boolean isValidSubjectName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        for (AvailableSubject subject : AvailableSubject.values()) {
+            if (subject.name().equals(test)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/subject/Subject.java
+++ b/src/main/java/seedu/address/model/subject/Subject.java
@@ -31,7 +31,7 @@ public class Subject implements Comparable<Subject> {
      * Returns true if a given string is a valid subject name.
      */
     public static boolean isValidSubjectName(String test) {
-        if(test.matches(VALIDATION_REGEX)){
+        if (test.matches(VALIDATION_REGEX)) {
             for (AvailableSubject subject : AvailableSubject.values()) {
                 if (subject.name().equals(test)) {
                     return true;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -42,7 +42,7 @@ public class SampleDataUtil {
                 Optional.of(new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18")),
                 Optional.of(new Name("Ben Yu")),
                 Optional.of(new Phone("99272758")),
-                getSubjectSet("math", "physics"), getLessonSet(" monday 1800")),
+                getSubjectSet("math", "phys"), getLessonSet(" monday 1800")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                 Optional.of(new School("Cde Secondary School")),
                 Optional.of(new Email("charlotte@example.com")),
@@ -56,21 +56,21 @@ public class SampleDataUtil {
                 Optional.of(new Address("Blk 436 Serangoon Gardens Street 26, #16-43")),
                 Optional.of(new Name("Li Li")),
                 Optional.of(new Phone("91031288")),
-                getSubjectSet("history"), getLessonSet("tuesday 1000")),
+                getSubjectSet("hist"), getLessonSet("tuesday 1000")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"),
                 Optional.of(new School("Efg Secondary School")),
                 Optional.of(new Email("irfan@example.com")),
                 Optional.of(new Address("Blk 47 Tampines Street 20, #17-35")),
                 Optional.of(new Name("Frank Ibrahim")),
                 Optional.of(new Phone("92492022")),
-                getSubjectSet("chinese"), getLessonSet("wednesday 1400")),
+                getSubjectSet("cn"), getLessonSet("wednesday 1400")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"),
                 Optional.of(new School("Efg Secondary School")),
                 Optional.of(new Email("royb@example.com")),
                 Optional.of(new Address("Blk 45 Aljunied Street 85, #11-31")),
                 Optional.of(new Name("Bob Balakrishnan")),
                 Optional.of(new Phone("92624411")),
-                getSubjectSet("physics"), getLessonSet("wednesday 1200"))
+                getSubjectSet("phys"), getLessonSet("wednesday 1200"))
         };
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -7,7 +7,7 @@
     "address": "123, Jurong West Ave 6, #08-111",
     "guardianName" : "Amanda Pauline",
     "guardianPhone" : "94351254",
-    "subjects": [ "physics" ],
+    "subjects": [ "phys" ],
     "lessons" : [ ]
   }, {
     "name": "Alice Pauline",

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -8,7 +8,7 @@
     "address" : "123, Jurong West Ave 6, #08-111",
     "guardianName" : "Amanda Pauline",
     "guardianPhone" : "94351254",
-    "subjects" : [ "physics" ],
+    "subjects" : [ "phys" ],
     "lessons" : [ "Sunday 1000"]
   }, {
     "name" : "Benson Meier",
@@ -18,7 +18,7 @@
     "address" : "311, Clementi Ave 2, #02-25",
     "guardianName" : "Jay Maier",
     "guardianPhone" : "98765433",
-    "subjects" : [ "chinese", "math" ],
+    "subjects" : [ "cn", "math" ],
     "lessons" : [ "Monday 1800" ]
   }, {
     "name" : "Carl Kurz",
@@ -38,7 +38,7 @@
     "address" : "10th street",
     "guardianName" : "Jay Maier",
     "guardianPhone" : "98765433",
-    "subjects" : [ "chinese" ],
+    "subjects" : [ "cn" ],
     "lessons" : [ ]
   }, {
     "name" : "Elle Meyer",

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -44,8 +44,8 @@ public class CommandTestUtil {
     public static final String VALID_GUARDIAN_NAME_BOB = "Ben Choo";
     public static final String VALID_GUARDIAN_PHONE_AMY = "33333333";
     public static final String VALID_GUARDIAN_PHONE_BOB = "44444444";
-    public static final String VALID_SUBJECT_CHEM = "chemistry";
-    public static final String VALID_SUBJECT_MATH = "mathematics";
+    public static final String VALID_SUBJECT_CHEM = "chem";
+    public static final String VALID_SUBJECT_MATH = "math";
     public static final String VALID_LESSON_AMY = "Monday 1500";
     public static final String VALID_LESSON_BOB = "Wednesday 1100";
 
@@ -72,7 +72,7 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
-    public static final String INVALID_SUBJECT_DESC = " " + PREFIX_SUBJECT + "hubby*"; // '*' not allowed in subjects
+    public static final String INVALID_SUBJECT_DESC = " " + PREFIX_SUBJECT + "hubby"; // 'hubby' is not a subject
     public static final String INVALID_LESSON_DESC = " " + PREFIX_LESSON + "Monday"; // time must be included after day
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -94,7 +94,7 @@ public class SearchCommandTest {
     @Test
     public void execute_multipleSubjectKeywords_multipleStudentsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        NameSchoolAndSubjectContainsKeywordsPredicate predicate = preparePredicate(" t/chinese math");
+        NameSchoolAndSubjectContainsKeywordsPredicate predicate = preparePredicate(" t/cn math");
         SearchCommand command = new SearchCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -32,8 +32,8 @@ public class ParserUtilTest {
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
-    private static final String VALID_SUBJECT_1 = "history";
-    private static final String VALID_SUBJECT_2 = "physics";
+    private static final String VALID_SUBJECT_1 = "hist";
+    private static final String VALID_SUBJECT_2 = "phys";
 
     private static final String WHITESPACE = " \t\r\n";
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -36,19 +36,19 @@ public class TypicalPersons {
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withSchool("Jurong West Secondary School")
             .withGuardianName("Amanda Pauline").withGuardianPhone("94351254")
-            .withSubjects("physics").withLessons("Sunday 1000").build();
+            .withSubjects("phys").withLessons("Sunday 1000").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withSchool("Clementi Town Secondary School").withGuardianName("Jay Maier")
-            .withGuardianPhone("98765433").withSubjects("chinese", "math")
+            .withGuardianPhone("98765433").withSubjects("cn", "math")
             .withLessons("Monday 1800").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withSchool("Wall Street Secondary School")
             .withGuardianName("Louis Kurz").withGuardianPhone("95352564").withLessons("Friday 1000").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withSchool("Clementi Town Secondary School")
-            .withGuardianName("Jay Maier").withGuardianPhone("98765433").withSubjects("chinese").build();
+            .withGuardianName("Jay Maier").withGuardianPhone("98765433").withSubjects("cn").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").withSchool("Michegan Secondary School")
             .withGuardianName("John Meyer").withGuardianPhone("9482225").build();


### PR DESCRIPTION
Available subject names in TutorsPet current version are `bio`, `chem`, `cn`, `econ`, `eng`, `geo`, `hist`, `math`, `phys`.