### PR TITLE
Fix bug in error messages for delete-date

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,7 +10,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_INVALID_IMPORTANT_DATE_DISPLAYED_INDEX = "There is no important date with " +
-        "this given index.";
+    public static final String MESSAGE_INVALID_IMPORTANT_DATE_DISPLAYED_INDEX = "There is no important date with "
+        + "this given index.";
 
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,7 +10,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_INVALID_IMPORTANT_DATE_DISPLAYED_INDEX = "The important date index provided is"
-        + " invalid";
+    public static final String MESSAGE_INVALID_IMPORTANT_DATE_DISPLAYED_INDEX = "There is no important date with " +
+        "this given index.";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteDateCommand.java
@@ -20,7 +20,7 @@ public class DeleteDateCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Deletes the important date identified by the index number used in the displayed important dates list.\n"
-        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Parameters: INDEX (must be a positive integer and lesser than 2147483647)\n"
         + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_DATE_SUCCESS = "Deleted Date: %1$s";


### PR DESCRIPTION
Makes the distinction clearer between invalid index input and index that does not exist in current list of important dates.

Fixes #141 

